### PR TITLE
Add PyTorch SAC pipeline for Windows-compatible training

### DIFF
--- a/examples/torch_analyze.py
+++ b/examples/torch_analyze.py
@@ -1,0 +1,183 @@
+"""Generate publication-ready figures from torch_sac training logs."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+from typing import Iterable
+
+
+try:
+    import pandas as pd
+except ModuleNotFoundError as exc:  # pragma: no cover - triggered when pandas is missing
+    raise SystemExit(
+        "pandas is required for torch_analyze; install it via `pip install pandas` or"
+        " include it through requirements-windows.txt"
+    ) from exc
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "logs",
+        nargs="+",
+        help="Paths to progress.csv files or directories that contain them.",
+    )
+    parser.add_argument(
+        "--labels",
+        nargs="*",
+        help="Optional labels for each run; must match the number of logs when provided.",
+    )
+    parser.add_argument(
+        "--output-dir",
+        type=str,
+        default="analysis",
+        help="Directory where figures and tables will be written.",
+    )
+    parser.add_argument(
+        "--smoothing-window",
+        type=int,
+        default=10,
+        help="Moving average window used to smooth curves for visualisation.",
+    )
+    parser.add_argument(
+        "--episode-window",
+        type=int,
+        default=50,
+        help="How many of the most recent episodes to include in summary statistics.",
+    )
+    parser.add_argument(
+        "--success-thresholds",
+        type=float,
+        nargs="*",
+        default=(),
+        help="Evaluation return targets (e.g. 3000) to compute time-to-threshold metrics.",
+    )
+    parser.add_argument(
+        "--style",
+        type=str,
+        default="whitegrid",
+        help="Seaborn style to apply when rendering the figure.",
+    )
+    parser.add_argument(
+        "--palette",
+        type=str,
+        default="deep",
+        help="Color palette used when plotting multiple runs.",
+    )
+    parser.add_argument(
+        "--figure-format",
+        type=str,
+        default="png",
+        choices=["png", "pdf", "svg"],
+        help="Image format for the learning curve figure.",
+    )
+    parser.add_argument(
+        "--dpi",
+        type=int,
+        default=300,
+        help="Figure resolution in dots per inch.",
+    )
+    parser.add_argument(
+        "--title",
+        type=str,
+        default=None,
+        help="Optional title to add to the generated figure.",
+    )
+    parser.add_argument(
+        "--latex",
+        action="store_true",
+        help="Also export the summary table as LaTeX for inclusion in papers.",
+    )
+    parser.add_argument(
+        "--markdown",
+        action="store_true",
+        help="Also export the summary table as GitHub-flavoured Markdown.",
+    )
+    return parser.parse_args()
+
+
+def _resolve_paths(raw_paths: Iterable[str]) -> list[Path]:
+    resolved: list[Path] = []
+    for raw in raw_paths:
+        path = Path(raw)
+        if path.is_dir():
+            csv_candidate = path / "progress.csv"
+            if not csv_candidate.exists():
+                raise FileNotFoundError(f"Directory {path} does not contain a progress.csv file")
+            path = csv_candidate
+        elif path.suffix.lower() != ".csv":
+            raise ValueError(f"Expected a .csv file or directory, got: {path}")
+        resolved.append(path)
+    return resolved
+
+
+def main() -> None:
+    args = _parse_args()
+
+    try:  # pragma: no cover - optional dependency for headless rendering
+        import matplotlib
+
+        if matplotlib.get_backend().lower() != "agg":
+            matplotlib.use("Agg", force=False)
+    except ModuleNotFoundError:
+        pass
+
+    paths = _resolve_paths(args.logs)
+    if args.labels and len(args.labels) != len(paths):
+        raise ValueError("--labels must have the same length as the number of log files")
+
+    from torch_sac.analysis import (
+        SummaryConfig,
+        load_multiple_runs,
+        plot_learning_curves,
+        summarize_training_runs,
+    )
+
+    combined = load_multiple_runs(paths, labels=args.labels)
+    summary = summarize_training_runs(
+        combined,
+        config=SummaryConfig(
+            episode_window=args.episode_window,
+            success_thresholds=tuple(args.success_thresholds),
+        ),
+    )
+
+    output_dir = Path(args.output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    figure = plot_learning_curves(
+        combined,
+        smoothing_window=args.smoothing_window,
+        style=args.style,
+        palette=args.palette,
+    )
+    if args.title:
+        figure.suptitle(args.title, fontsize=14, fontweight="bold")
+
+    figure_path = output_dir / f"learning_curves.{args.figure_format}"
+    figure.savefig(figure_path, dpi=args.dpi, bbox_inches="tight")
+
+    import matplotlib.pyplot as plt
+
+    plt.close(figure)
+
+    summary_path = output_dir / "summary_metrics.csv"
+    summary.to_csv(summary_path, index=False)
+
+    if args.latex:
+        summary.to_latex(output_dir / "summary_metrics.tex", index=False, float_format="{:.2f}".format)
+    if args.markdown:
+        summary.to_markdown(output_dir / "summary_metrics.md", index=False)
+
+    # Echo a nicely formatted table to the terminal for quick inspection.
+    print("\nSummary metrics:\n")
+    with pd.option_context("display.float_format", "{:.2f}".format):  # type: ignore[attr-defined]
+        print(summary.to_string(index=False))
+    print(f"\nFigure saved to: {figure_path}")
+    print(f"Summary CSV saved to: {summary_path}")
+
+
+if __name__ == "__main__":
+    main()
+

--- a/examples/torch_train.py
+++ b/examples/torch_train.py
@@ -1,0 +1,85 @@
+"""Command line entry point for training the PyTorch SAC agent."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+from torch_sac import TrainConfig, train
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Train Soft Actor-Critic with PyTorch.")
+    parser.add_argument("--env-id", default="Walker2d-v4", help="Gym environment id.")
+    parser.add_argument("--seed", type=int, default=0, help="Random seed.")
+    parser.add_argument("--total-steps", type=int, default=1_000_000, help="Total environment steps.")
+    parser.add_argument("--start-steps", type=int, default=10_000, help="Steps of random exploration.")
+    parser.add_argument("--update-after", type=int, default=1_000, help="Number of steps before updates start.")
+    parser.add_argument("--update-every", type=int, default=1, help="Environment steps between gradient updates.")
+    parser.add_argument("--gradient-steps", type=int, default=1, help="Gradient steps to run when updating.")
+    parser.add_argument("--batch-size", type=int, default=256, help="Batch size for critic updates.")
+    parser.add_argument("--replay-size", type=int, default=1_000_000, help="Replay buffer capacity.")
+    parser.add_argument("--gamma", type=float, default=0.99, help="Discount factor.")
+    parser.add_argument("--tau", type=float, default=0.005, help="Target smoothing coefficient.")
+    parser.add_argument("--lr", type=float, default=3e-4, help="Learning rate for all optimizers.")
+    parser.add_argument(
+        "--hidden-dims",
+        type=int,
+        nargs="+",
+        default=(256, 256),
+        help="Hidden layer sizes of policy and critic networks.",
+    )
+    parser.add_argument("--eval-interval", type=int, default=5_000, help="How often to run evaluation (0 to disable).")
+    parser.add_argument("--eval-episodes", type=int, default=5, help="Number of evaluation episodes.")
+    parser.add_argument("--save-interval", type=int, default=100_000, help="How often to checkpoint (0 to disable).")
+    parser.add_argument("--log-dir", default="runs/torch_sac", help="Directory where run artifacts are stored.")
+    parser.add_argument("--device", default=None, help="PyTorch device string (e.g. 'cpu' or 'cuda').")
+    parser.add_argument("--target-entropy", type=float, default=None, help="Optional manual target entropy.")
+    parser.add_argument(
+        "--disable-auto-entropy",
+        action="store_true",
+        help="Disable automatic entropy coefficient tuning.",
+    )
+    parser.add_argument(
+        "--stochastic-eval",
+        action="store_true",
+        help="Use stochastic actions during evaluation instead of deterministic ones.",
+    )
+    parser.add_argument(
+        "--max-episode-steps", type=int, default=None, help="Override environment time limit if provided."
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    config = TrainConfig(
+        env_id=args.env_id,
+        seed=args.seed,
+        total_steps=args.total_steps,
+        start_steps=args.start_steps,
+        update_after=args.update_after,
+        update_every=args.update_every,
+        gradient_steps=args.gradient_steps,
+        batch_size=args.batch_size,
+        replay_size=args.replay_size,
+        gamma=args.gamma,
+        tau=args.tau,
+        lr=args.lr,
+        hidden_dims=tuple(args.hidden_dims),
+        auto_entropy_tuning=not args.disable_auto_entropy,
+        target_entropy=args.target_entropy,
+        eval_interval=args.eval_interval,
+        eval_episodes=args.eval_episodes,
+        deterministic_eval=not args.stochastic_eval,
+        save_interval=args.save_interval,
+        log_dir=Path(args.log_dir),
+        device=args.device,
+        max_episode_steps=args.max_episode_steps,
+    )
+    run_dir = train(config)
+    print(f"Training artifacts written to {run_dir}")
+
+
+if __name__ == "__main__":
+    main()

--- a/requirements-windows.txt
+++ b/requirements-windows.txt
@@ -1,0 +1,6 @@
+numpy>=1.23
+gymnasium[mujoco]==0.29.1
+torch>=2.2
+pandas>=1.5
+matplotlib>=3.7
+seaborn>=0.12

--- a/tests/torch_sac/test_agent.py
+++ b/tests/torch_sac/test_agent.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+import pytest
+
+np = pytest.importorskip("numpy")
+pytest.importorskip("torch")
+
+from torch_sac.agent import SACAgent
+
+
+class DummyObservationSpace:
+    def __init__(self, dim: int) -> None:
+        self.shape = (dim,)
+
+
+class DummyActionSpace:
+    def __init__(self, dim: int, low: float = -1.0, high: float = 1.0) -> None:
+        self.low = np.full(dim, low, dtype=np.float32)
+        self.high = np.full(dim, high, dtype=np.float32)
+        self.shape = (dim,)
+
+
+def _make_batch(batch_size: int, obs_dim: int, act_dim: int) -> dict[str, np.ndarray]:
+    rng = np.random.default_rng(0)
+    return {
+        "observations": rng.standard_normal((batch_size, obs_dim), dtype=np.float32),
+        "actions": rng.uniform(-1.0, 1.0, size=(batch_size, act_dim)).astype(np.float32),
+        "rewards": rng.standard_normal((batch_size, 1), dtype=np.float32),
+        "next_observations": rng.standard_normal((batch_size, obs_dim), dtype=np.float32),
+        "dones": rng.integers(0, 2, size=(batch_size, 1)).astype(np.float32),
+    }
+
+
+def test_sac_agent_update_runs() -> None:
+    obs_dim, act_dim = 5, 3
+    agent = SACAgent(
+        observation_space=DummyObservationSpace(obs_dim),
+        action_space=DummyActionSpace(act_dim),
+        hidden_dims=(32, 32),
+        lr=5e-4,
+        automatic_entropy_tuning=True,
+        device="cpu",
+    )
+    batch = _make_batch(batch_size=64, obs_dim=obs_dim, act_dim=act_dim)
+    metrics = agent.update(batch)
+    assert "policy_loss" in metrics
+    assert "qf1_loss" in metrics
+    action = agent.act(np.zeros(obs_dim, dtype=np.float32))
+    assert action.shape == (act_dim,)

--- a/tests/torch_sac/test_analysis.py
+++ b/tests/torch_sac/test_analysis.py
@@ -1,0 +1,72 @@
+"""Tests for the torch_sac.analysis utilities."""
+
+from __future__ import annotations
+
+import math
+from pathlib import Path
+
+import pytest
+
+
+pandas = pytest.importorskip("pandas")
+matplotlib = pytest.importorskip("matplotlib")
+pytest.importorskip("seaborn")
+
+from torch_sac.analysis import (  # noqa: E402  - imported after pytest.importorskip
+    SummaryConfig,
+    plot_learning_curves,
+    smooth_series,
+    summarize_training_runs,
+)
+
+
+def _make_dataframe() -> "pandas.DataFrame":
+    data = {
+        "step": [100, 200, 300, 400, 500, 600],
+        "episodes": [1, 2, 2, 3, 3, 4],
+        "episode_return": [100.0, 110.0, math.nan, 120.0, math.nan, 130.0],
+        "episode_length": [10, 11, math.nan, 12, math.nan, 13],
+        "eval_return": [math.nan, math.nan, 200.0, math.nan, 250.0, math.nan],
+        "eval_length": [math.nan, math.nan, 100.0, math.nan, 110.0, math.nan],
+        "policy_loss": [0.5, 0.4, 0.35, 0.3, 0.28, 0.25],
+        "qf1_loss": [1.0, 0.8, 0.7, 0.6, 0.55, 0.5],
+        "qf2_loss": [1.1, 0.9, 0.75, 0.65, 0.6, 0.55],
+        "alpha": [0.2, 0.19, 0.18, 0.17, 0.16, 0.15],
+        "entropy": [0.9, 0.85, 0.8, 0.78, 0.75, 0.72],
+    }
+    frame = pandas.DataFrame(data)
+    frame["run"] = "seed-1"
+    return frame
+
+
+def test_smooth_series_applies_moving_average() -> None:
+    series = pandas.Series([0.0, 1.0, 2.0, 3.0, 4.0])
+    smoothed = smooth_series(series, window=3)
+    expected = pandas.Series([0.0, 0.5, 1.0, 2.0, 3.0])
+    pandas.testing.assert_series_equal(smoothed.round(6), expected)
+
+
+def test_summarize_training_runs_returns_key_metrics() -> None:
+    frame = _make_dataframe()
+    summary = summarize_training_runs(
+        frame,
+        config=SummaryConfig(episode_window=10, success_thresholds=(240.0,)),
+    )
+    assert summary.loc[0, "final_eval_return"] == pytest.approx(250.0)
+    assert summary.loc[0, "best_eval_step"] == pytest.approx(500.0)
+    assert summary.loc[0, "normalized_eval_auc"] == pytest.approx(225.0)
+    assert summary.loc[0, "mean_episode_return_last_window"] == pytest.approx(115.0)
+    assert summary.loc[0, "episode_return_trend_last_window"] == pytest.approx(10.0)
+    assert summary.loc[0, "step_to_return_240"] == pytest.approx(500.0)
+
+
+def test_plot_learning_curves_creates_figure(tmp_path: Path) -> None:
+    frame = _make_dataframe()
+    matplotlib.use("Agg", force=False)
+    figure = plot_learning_curves(frame, smoothing_window=2)
+    output_file = tmp_path / "curves.png"
+    figure.savefig(output_file)
+    assert output_file.exists()
+    import matplotlib.pyplot as plt
+
+    plt.close(figure)

--- a/tests/torch_sac/test_networks.py
+++ b/tests/torch_sac/test_networks.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+import pytest
+
+np = pytest.importorskip("numpy")
+torch = pytest.importorskip("torch")
+
+from torch_sac.networks import GaussianPolicy, QNetwork
+
+
+def _make_action_space(low: float, high: float, dim: int):
+    class _DummySpace:
+        def __init__(self) -> None:
+            self.low = np.full(dim, low, dtype=np.float32)
+            self.high = np.full(dim, high, dtype=np.float32)
+            self.shape = (dim,)
+
+    return _DummySpace()
+
+
+def test_gaussian_policy_sample_shapes() -> None:
+    action_space = _make_action_space(-1.0, 1.0, dim=2)
+    policy = GaussianPolicy(observation_dim=3, action_space=action_space, hidden_dims=(32, 32))
+    observation = torch.zeros(4, 3)
+    action, log_prob, mean_action = policy.sample(observation)
+    assert action.shape == (4, 2)
+    assert log_prob.shape == (4, 1)
+    assert mean_action.shape == (4, 2)
+    assert torch.all(action <= 1.0001)
+    assert torch.all(action >= -1.0001)
+
+
+def test_q_network_outputs_scalar() -> None:
+    q_net = QNetwork(observation_dim=3, action_dim=2, hidden_dims=(16, 16))
+    observation = torch.randn(5, 3)
+    action = torch.randn(5, 2)
+    q_values = q_net(observation, action)
+    assert q_values.shape == (5, 1)

--- a/tests/torch_sac/test_replay_buffer.py
+++ b/tests/torch_sac/test_replay_buffer.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+import pytest
+
+np = pytest.importorskip("numpy")
+
+from torch_sac.replay_buffer import ReplayBuffer
+
+
+def test_replay_buffer_add_and_sample() -> None:
+    buffer = ReplayBuffer((3,), (2,), capacity=5)
+    for idx in range(5):
+        observation = np.full(3, idx, dtype=np.float32)
+        action = np.full(2, idx, dtype=np.float32)
+        reward = float(idx)
+        next_observation = observation + 1
+        done = float(idx % 2)
+        buffer.add(observation, action, reward, next_observation, done)
+
+    batch = buffer.sample(batch_size=3)
+    assert batch["observations"].shape == (3, 3)
+    assert batch["actions"].shape == (3, 2)
+    assert batch["rewards"].shape == (3, 1)
+    assert batch["next_observations"].shape == (3, 3)
+    assert batch["dones"].shape == (3, 1)
+    assert batch["observations"].dtype == np.float32
+    assert buffer.capacity == 5
+    assert len(buffer) == 5
+
+
+def test_sampling_from_empty_buffer_raises() -> None:
+    buffer = ReplayBuffer((1,), (1,), capacity=1)
+    with pytest.raises(ValueError):
+        buffer.sample(1)

--- a/torch_sac/__init__.py
+++ b/torch_sac/__init__.py
@@ -1,0 +1,25 @@
+"""PyTorch implementation of Soft Actor-Critic tailored for modern Python."""
+
+from .agent import SACAgent
+from .analysis import (
+    SummaryConfig,
+    load_multiple_runs,
+    load_progress_csv,
+    plot_learning_curves,
+    smooth_series,
+    summarize_training_runs,
+)
+from .config import TrainConfig
+from .trainer import train
+
+__all__ = [
+    "SACAgent",
+    "TrainConfig",
+    "train",
+    "SummaryConfig",
+    "load_multiple_runs",
+    "load_progress_csv",
+    "plot_learning_curves",
+    "smooth_series",
+    "summarize_training_runs",
+]

--- a/torch_sac/agent.py
+++ b/torch_sac/agent.py
@@ -1,0 +1,161 @@
+"""Soft Actor-Critic agent implemented with PyTorch."""
+
+from __future__ import annotations
+
+import itertools
+from pathlib import Path
+from typing import Dict, Optional
+
+import numpy as np
+import torch
+import torch.nn.functional as F
+from torch.optim import Adam
+
+from .networks import GaussianPolicy, QNetwork
+from .utils import hard_update, soft_update, to_tensor
+
+
+class SACAgent:
+    """Encapsulates policy, critics and entropy tuning logic."""
+
+    def __init__(
+        self,
+        observation_space,
+        action_space,
+        hidden_dims: tuple[int, ...] = (256, 256),
+        lr: float = 3e-4,
+        gamma: float = 0.99,
+        tau: float = 0.005,
+        alpha: float = 0.2,
+        automatic_entropy_tuning: bool = True,
+        target_entropy: Optional[float] = None,
+        device: Optional[str] = None,
+    ) -> None:
+        self.device = torch.device(device or ("cuda" if torch.cuda.is_available() else "cpu"))
+        observation_dim = int(np.prod(observation_space.shape))
+        action_dim = int(np.prod(action_space.shape))
+
+        self.policy = GaussianPolicy(observation_dim, action_space, hidden_dims).to(self.device)
+        self.qf1 = QNetwork(observation_dim, action_dim, hidden_dims).to(self.device)
+        self.qf2 = QNetwork(observation_dim, action_dim, hidden_dims).to(self.device)
+        self.target_qf1 = QNetwork(observation_dim, action_dim, hidden_dims).to(self.device)
+        self.target_qf2 = QNetwork(observation_dim, action_dim, hidden_dims).to(self.device)
+        hard_update(self.qf1, self.target_qf1)
+        hard_update(self.qf2, self.target_qf2)
+
+        self.policy_optimizer = Adam(self.policy.parameters(), lr=lr)
+        q_parameters = itertools.chain(self.qf1.parameters(), self.qf2.parameters())
+        self.q_optimizer = Adam(q_parameters, lr=lr)
+
+        self.gamma = gamma
+        self.tau = tau
+        self.automatic_entropy_tuning = automatic_entropy_tuning
+
+        if self.automatic_entropy_tuning:
+            if target_entropy is None:
+                target_entropy = -float(action_dim)
+            self.target_entropy = target_entropy
+            self.log_alpha = torch.zeros(1, requires_grad=True, device=self.device)
+            self.alpha_optimizer = Adam([self.log_alpha], lr=lr)
+            self._alpha = None
+        else:
+            self.target_entropy = None
+            self.log_alpha = None
+            self.alpha_optimizer = None
+            self._alpha = torch.tensor(alpha, device=self.device)
+
+    @property
+    def alpha(self) -> torch.Tensor:
+        if self.automatic_entropy_tuning:
+            return self.log_alpha.exp()
+        return self._alpha
+
+    def act(self, observation: np.ndarray, deterministic: bool = False) -> np.ndarray:
+        self.policy.eval()
+        with torch.no_grad():
+            obs = torch.as_tensor(observation, dtype=torch.float32, device=self.device).unsqueeze(0)
+            action = self.policy.act(obs, deterministic=deterministic)
+        self.policy.train()
+        return action.cpu().numpy()[0]
+
+    def update(self, batch: Dict[str, np.ndarray]) -> Dict[str, float]:
+        observations = to_tensor(batch["observations"], self.device)
+        actions = to_tensor(batch["actions"], self.device)
+        rewards = to_tensor(batch["rewards"], self.device)
+        next_observations = to_tensor(batch["next_observations"], self.device)
+        dones = to_tensor(batch["dones"], self.device)
+
+        batch_size = observations.shape[0]
+        observations = observations.view(batch_size, -1)
+        actions = actions.view(batch_size, -1)
+        next_observations = next_observations.view(batch_size, -1)
+
+        with torch.no_grad():
+            next_actions, next_log_probs, _ = self.policy.sample(next_observations)
+            target_q1 = self.target_qf1(next_observations, next_actions)
+            target_q2 = self.target_qf2(next_observations, next_actions)
+            target_v = torch.min(target_q1, target_q2) - self.alpha * next_log_probs
+            target_q = rewards + (1.0 - dones) * self.gamma * target_v
+
+        current_q1 = self.qf1(observations, actions)
+        current_q2 = self.qf2(observations, actions)
+        qf1_loss = F.mse_loss(current_q1, target_q)
+        qf2_loss = F.mse_loss(current_q2, target_q)
+        q_loss = qf1_loss + qf2_loss
+
+        self.q_optimizer.zero_grad()
+        q_loss.backward()
+        self.q_optimizer.step()
+
+        new_actions, log_pi, _ = self.policy.sample(observations)
+        min_q_new_actions = torch.min(self.qf1(observations, new_actions), self.qf2(observations, new_actions))
+        policy_loss = (self.alpha.detach() * log_pi - min_q_new_actions).mean()
+
+        self.policy_optimizer.zero_grad()
+        policy_loss.backward()
+        self.policy_optimizer.step()
+
+        alpha_loss_value = float("nan")
+        if self.automatic_entropy_tuning:
+            alpha_loss = -(self.log_alpha * (log_pi + self.target_entropy).detach()).mean()
+            self.alpha_optimizer.zero_grad()
+            alpha_loss.backward()
+            self.alpha_optimizer.step()
+            alpha_loss_value = float(alpha_loss.item())
+
+        soft_update(self.qf1, self.target_qf1, self.tau)
+        soft_update(self.qf2, self.target_qf2, self.tau)
+
+        return {
+            "qf1_loss": float(qf1_loss.item()),
+            "qf2_loss": float(qf2_loss.item()),
+            "policy_loss": float(policy_loss.item()),
+            "alpha": float(self.alpha.item()),
+            "entropy": float(-log_pi.mean().item()),
+            "alpha_loss": float(alpha_loss_value),
+        }
+
+    def save(self, path: str | Path) -> None:
+        checkpoint = {
+            "policy": self.policy.state_dict(),
+            "qf1": self.qf1.state_dict(),
+            "qf2": self.qf2.state_dict(),
+            "target_qf1": self.target_qf1.state_dict(),
+            "target_qf2": self.target_qf2.state_dict(),
+            "log_alpha": self.log_alpha.detach().cpu().numpy() if self.log_alpha is not None else None,
+            "automatic_entropy_tuning": self.automatic_entropy_tuning,
+        }
+        torch.save(checkpoint, Path(path))
+
+    def load(self, path: str | Path) -> None:
+        checkpoint = torch.load(Path(path), map_location=self.device)
+        self.policy.load_state_dict(checkpoint["policy"])
+        self.qf1.load_state_dict(checkpoint["qf1"])
+        self.qf2.load_state_dict(checkpoint["qf2"])
+        self.target_qf1.load_state_dict(checkpoint["target_qf1"])
+        self.target_qf2.load_state_dict(checkpoint["target_qf2"])
+        if checkpoint.get("automatic_entropy_tuning", False) and self.log_alpha is not None:
+            log_alpha = checkpoint.get("log_alpha")
+            if log_alpha is not None:
+                self.log_alpha.data = torch.as_tensor(log_alpha, device=self.device)
+

--- a/torch_sac/analysis.py
+++ b/torch_sac/analysis.py
@@ -1,0 +1,353 @@
+"""Utilities for turning SAC training logs into publication-ready figures."""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable, List, Sequence
+
+import numpy as np
+
+
+try:  # pragma: no cover - optional dependency for analysis utilities
+    import matplotlib.pyplot as plt
+    import seaborn as sns
+    _HAVE_PLOTTING = True
+except ModuleNotFoundError:  # pragma: no cover - gracefully degrade when plotting stack is absent
+    plt = None  # type: ignore
+    sns = None  # type: ignore
+    _HAVE_PLOTTING = False
+
+
+try:  # pragma: no cover - optional dependency for analysis utilities
+    import pandas as pd
+    _HAVE_PANDAS = True
+except ModuleNotFoundError:  # pragma: no cover - allow importing the module without pandas installed
+    pd = None  # type: ignore
+    _HAVE_PANDAS = False
+
+
+@dataclass(frozen=True)
+class SummaryConfig:
+    """Configuration controlling how summary tables are generated."""
+
+    episode_window: int = 50
+    success_thresholds: Sequence[float] = ()
+
+
+def _require_pandas() -> None:
+    if not _HAVE_PANDAS:  # pragma: no cover - triggered only when pandas is missing
+        raise ImportError(
+            "pandas is required for torch_sac.analysis; install it via "
+            "`pip install pandas` or use requirements-windows.txt"
+        )
+
+
+def _require_plotting() -> None:
+    if not _HAVE_PLOTTING:  # pragma: no cover - triggered only when plotting stack is missing
+        raise ImportError(
+            "matplotlib and seaborn are required for plotting; install them via "
+            "`pip install matplotlib seaborn` or use requirements-windows.txt"
+        )
+
+
+def load_progress_csv(path: str | Path, run_label: str | None = None) -> "pd.DataFrame":
+    """Load a ``progress.csv`` file produced by :mod:`torch_sac` training.
+
+    Parameters
+    ----------
+    path:
+        Path to the CSV file.
+    run_label:
+        Optional human-readable label that is stored in the ``run`` column for downstream
+        aggregation. If omitted, the parent directory name is used.
+    """
+
+    _require_pandas()
+
+    csv_path = Path(path)
+    if csv_path.is_dir():
+        csv_path = csv_path / "progress.csv"
+    if not csv_path.exists():
+        raise FileNotFoundError(f"No progress.csv found at {csv_path}")
+
+    frame = pd.read_csv(csv_path)
+    if "step" not in frame.columns:
+        raise ValueError("progress.csv is missing the required 'step' column")
+
+    frame = frame.sort_values("step").reset_index(drop=True)
+    frame["run"] = run_label or csv_path.parent.name
+    return frame
+
+
+def load_multiple_runs(paths: Iterable[str | Path], labels: Sequence[str] | None = None) -> "pd.DataFrame":
+    """Load multiple progress logs and concatenate them with a ``run`` column."""
+
+    _require_pandas()
+
+    frames: List[pd.DataFrame] = []
+    provided_labels = list(labels) if labels is not None else None
+
+    for index, raw_path in enumerate(paths):
+        label = provided_labels[index] if provided_labels else None
+        frame = load_progress_csv(raw_path, run_label=label)
+        frames.append(frame)
+
+    if not frames:
+        raise ValueError("No log files provided")
+
+    return pd.concat(frames, ignore_index=True, sort=False)
+
+
+def smooth_series(series: "pd.Series", window: int) -> "pd.Series":
+    """Apply a simple moving average with ``window`` samples."""
+
+    _require_pandas()
+
+    if window <= 1:
+        return series
+    return series.rolling(window=window, min_periods=1).mean()
+
+
+def _split_training_eval(frame: "pd.DataFrame") -> tuple["pd.DataFrame", "pd.DataFrame"]:
+    _require_pandas()
+
+    train_df = frame.dropna(subset=["episode_return"]) if "episode_return" in frame else pd.DataFrame()
+    eval_df = frame.dropna(subset=["eval_return"]) if "eval_return" in frame else pd.DataFrame()
+    return train_df, eval_df
+
+
+def _format_threshold(threshold: float) -> str:
+    formatted = f"{threshold:g}".replace("-", "neg")
+    return formatted.replace(".", "p")
+
+
+def summarize_training_runs(
+    frame: "pd.DataFrame", config: SummaryConfig | None = None
+) -> "pd.DataFrame":
+    """Compute descriptive statistics for one or more SAC training runs."""
+
+    _require_pandas()
+
+    if "run" not in frame.columns:
+        raise ValueError("Input frame must contain a 'run' column. Use load_progress_csv().")
+
+    cfg = config or SummaryConfig()
+    rows: List[dict[str, float | str]] = []
+
+    for run, run_frame in frame.groupby("run", sort=False):
+        train_df, eval_df = _split_training_eval(run_frame)
+        metrics: dict[str, float | str] = {"run": run}
+
+        if not eval_df.empty:
+            eval_returns = eval_df["eval_return"].astype(float)
+            eval_steps = eval_df["step"].astype(float)
+
+            metrics["final_eval_return"] = float(eval_returns.iloc[-1])
+            metrics["final_eval_length"] = float(eval_df["eval_length"].iloc[-1]) if "eval_length" in eval_df else math.nan
+            best_idx = int(eval_returns.idxmax())
+            metrics["best_eval_return"] = float(eval_returns.loc[best_idx])
+            metrics["best_eval_step"] = float(eval_steps.loc[best_idx])
+            if len(eval_df) >= 2:
+                total_span = float(eval_steps.iloc[-1] - eval_steps.iloc[0])
+                auc = float(np.trapz(eval_returns.values, eval_steps.values))
+                metrics["normalized_eval_auc"] = auc / total_span if total_span > 0 else auc
+            else:
+                metrics["normalized_eval_auc"] = float(eval_returns.iloc[0])
+
+            metrics["mean_eval_length"] = float(eval_df["eval_length"].mean()) if "eval_length" in eval_df else math.nan
+
+            for threshold in cfg.success_thresholds:
+                above = eval_df.loc[eval_returns >= threshold]
+                key = f"step_to_return_{_format_threshold(threshold)}"
+                metrics[key] = float(above["step"].iloc[0]) if not above.empty else math.nan
+        else:
+            metrics.update(
+                {
+                    "final_eval_return": math.nan,
+                    "final_eval_length": math.nan,
+                    "best_eval_return": math.nan,
+                    "best_eval_step": math.nan,
+                    "normalized_eval_auc": math.nan,
+                    "mean_eval_length": math.nan,
+                }
+            )
+            for threshold in cfg.success_thresholds:
+                metrics[f"step_to_return_{_format_threshold(threshold)}"] = math.nan
+
+        if not train_df.empty:
+            last_window = train_df.tail(cfg.episode_window)
+            episode_returns = last_window["episode_return"].astype(float)
+            metrics["mean_episode_return_last_window"] = float(episode_returns.mean())
+            metrics["median_episode_return_last_window"] = float(episode_returns.median())
+            metrics["std_episode_return_last_window"] = float(episode_returns.std(ddof=0))
+            metrics["episodes_recorded"] = float(len(train_df))
+            if "episode_length" in last_window:
+                metrics["mean_episode_length_last_window"] = float(last_window["episode_length"].mean())
+            else:
+                metrics["mean_episode_length_last_window"] = math.nan
+
+            if len(last_window) >= 2:
+                x = np.arange(len(last_window), dtype=np.float64)
+                slope, _ = np.polyfit(x, episode_returns.values, deg=1)
+                metrics["episode_return_trend_last_window"] = float(slope)
+            else:
+                metrics["episode_return_trend_last_window"] = math.nan
+        else:
+            metrics.update(
+                {
+                    "mean_episode_return_last_window": math.nan,
+                    "median_episode_return_last_window": math.nan,
+                    "std_episode_return_last_window": math.nan,
+                    "episodes_recorded": 0.0,
+                    "mean_episode_length_last_window": math.nan,
+                    "episode_return_trend_last_window": math.nan,
+                }
+            )
+
+        rows.append(metrics)
+
+    return pd.DataFrame(rows)
+
+
+def plot_learning_curves(
+    frame: "pd.DataFrame",
+    smoothing_window: int = 10,
+    style: str = "whitegrid",
+    palette: str | Sequence[str] = "deep",
+    figsize: tuple[int, int] = (15, 9),
+) -> "plt.Figure":
+    """Create a multi-panel figure visualising SAC training dynamics."""
+
+    _require_pandas()
+    _require_plotting()
+
+    if "run" not in frame.columns:
+        raise ValueError("Input frame must contain a 'run' column. Use load_progress_csv().")
+
+    sns.set_theme(style=style)
+
+    fig, axes = plt.subplots(2, 2, figsize=figsize)
+    axes = axes.reshape(2, 2)
+
+    palette_iter = sns.color_palette(palette, n_colors=len(frame["run"].unique()))
+
+    # Evaluation returns
+    eval_ax = axes[0, 0]
+    eval_ax.set_title("Evaluation return over training")
+    eval_ax.set_xlabel("Environment steps")
+    eval_ax.set_ylabel("Average return")
+
+    for color, (run, run_frame) in zip(palette_iter, frame.groupby("run", sort=False)):
+        _, eval_df = _split_training_eval(run_frame)
+        if eval_df.empty:
+            continue
+        eval_steps = eval_df["step"].astype(float)
+        eval_returns = eval_df["eval_return"].astype(float)
+        eval_ax.plot(eval_steps, eval_returns, color=color, alpha=0.3, linewidth=1.0)
+        smoothed = smooth_series(eval_returns, smoothing_window)
+        eval_ax.plot(eval_steps, smoothed, color=color, linewidth=2.0, label=run)
+
+    eval_ax.legend(loc="best", frameon=False)
+
+    # Episode returns
+    train_ax = axes[0, 1]
+    train_ax.set_title("Training episode return")
+    train_ax.set_xlabel("Environment steps")
+    train_ax.set_ylabel("Return per episode")
+
+    palette_iter = sns.color_palette(palette, n_colors=len(frame["run"].unique()))
+    for color, (run, run_frame) in zip(palette_iter, frame.groupby("run", sort=False)):
+        train_df, _ = _split_training_eval(run_frame)
+        if train_df.empty:
+            continue
+        episode_steps = train_df["step"].astype(float)
+        episode_returns = train_df["episode_return"].astype(float)
+        train_ax.scatter(episode_steps, episode_returns, color=color, alpha=0.2, s=10)
+        train_ax.plot(
+            episode_steps,
+            smooth_series(episode_returns, smoothing_window),
+            color=color,
+            linewidth=1.8,
+            label=run,
+        )
+
+    if len(frame["run"].unique()) == 1:
+        train_ax.legend(loc="best", frameon=False)
+
+    # Critic and actor losses
+    loss_ax = axes[1, 0]
+    loss_ax.set_title("Optimization losses")
+    loss_ax.set_xlabel("Environment steps")
+    loss_ax.set_ylabel("Loss value")
+
+    loss_columns = [col for col in ["policy_loss", "qf1_loss", "qf2_loss"] if col in frame.columns]
+    if loss_columns:
+        for column in loss_columns:
+            grouped = frame.dropna(subset=[column]).groupby("step", as_index=False)[column].mean()
+            if grouped.empty:
+                continue
+            loss_ax.plot(grouped["step"], grouped[column], label=column)
+        loss_ax.legend(loc="best", frameon=False)
+    else:
+        loss_ax.text(0.5, 0.5, "No loss metrics recorded", ha="center", va="center")
+
+    # Entropy temperature dynamics
+    alpha_ax = axes[1, 1]
+    alpha_ax.set_title("Entropy temperature and policy entropy")
+    alpha_ax.set_xlabel("Environment steps")
+
+    legend_handles: List = []
+    legend_labels: List[str] = []
+
+    if "alpha" in frame.columns:
+        alpha_grouped = frame.dropna(subset=["alpha"]).groupby("step", as_index=False)["alpha"].mean()
+        if not alpha_grouped.empty:
+            (line,) = alpha_ax.plot(
+                alpha_grouped["step"],
+                alpha_grouped["alpha"],
+                color="tab:blue",
+                label="alpha",
+            )
+            legend_handles.append(line)
+            legend_labels.append("alpha")
+        alpha_ax.set_ylabel("Temperature (alpha)", color="tab:blue")
+        alpha_ax.tick_params(axis="y", labelcolor="tab:blue")
+    else:
+        alpha_ax.set_ylabel("Temperature (alpha)")
+
+    if "entropy" in frame.columns:
+        entropy_ax = alpha_ax.twinx()
+        entropy_grouped = frame.dropna(subset=["entropy"]).groupby("step", as_index=False)["entropy"].mean()
+        if not entropy_grouped.empty:
+            (entropy_line,) = entropy_ax.plot(
+                entropy_grouped["step"],
+                entropy_grouped["entropy"],
+                color="tab:orange",
+                linestyle="--",
+                label="entropy",
+            )
+            legend_handles.append(entropy_line)
+            legend_labels.append("entropy")
+        entropy_ax.set_ylabel("Policy entropy", color="tab:orange")
+        entropy_ax.tick_params(axis="y", labelcolor="tab:orange")
+    if legend_handles:
+        alpha_ax.legend(legend_handles, legend_labels, loc="best", frameon=False)
+    else:
+        alpha_ax.text(0.5, 0.5, "No entropy metrics recorded", transform=alpha_ax.transAxes, ha="center", va="center")
+
+    fig.tight_layout()
+    sns.despine(fig)
+    return fig
+
+
+__all__ = [
+    "SummaryConfig",
+    "load_progress_csv",
+    "load_multiple_runs",
+    "smooth_series",
+    "summarize_training_runs",
+    "plot_learning_curves",
+]
+

--- a/torch_sac/config.py
+++ b/torch_sac/config.py
@@ -1,0 +1,40 @@
+"""Configuration dataclasses for the PyTorch SAC training pipeline."""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+from typing import Dict, Tuple
+
+
+@dataclass
+class TrainConfig:
+    """Runtime configuration for :func:`torch_sac.trainer.train`."""
+
+    env_id: str = "Walker2d-v4"
+    seed: int = 0
+    total_steps: int = 1_000_000
+    start_steps: int = 10_000
+    update_after: int = 1_000
+    update_every: int = 1
+    gradient_steps: int = 1
+    batch_size: int = 256
+    replay_size: int = 1_000_000
+    gamma: float = 0.99
+    tau: float = 0.005
+    lr: float = 3e-4
+    hidden_dims: Tuple[int, ...] = (256, 256)
+    auto_entropy_tuning: bool = True
+    target_entropy: float | None = None
+    eval_interval: int = 5_000
+    eval_episodes: int = 5
+    deterministic_eval: bool = True
+    save_interval: int = 100_000
+    log_dir: Path = field(default_factory=lambda: Path("runs"))
+    device: str | None = None
+    max_episode_steps: int | None = None
+
+    def to_dict(self) -> Dict[str, object]:
+        data = asdict(self)
+        data["log_dir"] = str(self.log_dir)
+        return data

--- a/torch_sac/logger.py
+++ b/torch_sac/logger.py
@@ -1,0 +1,38 @@
+"""Lightweight CSV logger used by the PyTorch SAC trainer."""
+
+from __future__ import annotations
+
+import csv
+from pathlib import Path
+from typing import Dict, Iterable, Optional
+
+
+class CSVLogger:
+    """Append-only CSV logger."""
+
+    def __init__(self, path: Path) -> None:
+        self._path = Path(path)
+        self._path.parent.mkdir(parents=True, exist_ok=True)
+        self._file = self._path.open("w", newline="")
+        self._writer: Optional[csv.DictWriter] = None
+        self._fieldnames: Optional[Iterable[str]] = None
+
+    def log(self, values: Dict[str, float]) -> None:
+        if self._writer is None:
+            self._fieldnames = list(values.keys())
+            self._writer = csv.DictWriter(self._file, fieldnames=self._fieldnames)
+            self._writer.writeheader()
+        assert self._fieldnames is not None
+        row = {key: values.get(key) for key in self._fieldnames}
+        self._writer.writerow(row)
+        self._file.flush()
+
+    def close(self) -> None:
+        if not self._file.closed:
+            self._file.close()
+
+    def __enter__(self) -> "CSVLogger":
+        return self
+
+    def __exit__(self, exc_type, exc, exc_tb) -> None:
+        self.close()

--- a/torch_sac/networks.py
+++ b/torch_sac/networks.py
@@ -1,0 +1,125 @@
+"""Neural network components for the PyTorch SAC implementation."""
+
+from __future__ import annotations
+
+from typing import Sequence, Tuple
+
+import numpy as np
+import torch
+import torch.nn as nn
+from torch.distributions import Normal
+
+
+LOG_STD_MIN_MAX = (-20.0, 2.0)
+EPS = 1e-6
+
+
+def _init_layer(layer: nn.Linear) -> None:
+    nn.init.xavier_uniform_(layer.weight)
+    nn.init.zeros_(layer.bias)
+
+
+class MLP(nn.Module):
+    """Configurable multi-layer perceptron."""
+
+    def __init__(
+        self,
+        input_dim: int,
+        hidden_dims: Sequence[int],
+        output_dim: int,
+        activation: type[nn.Module] = nn.ReLU,
+        output_activation: type[nn.Module] | None = None,
+    ) -> None:
+        super().__init__()
+        dims = [input_dim, *hidden_dims, output_dim]
+        layers: list[nn.Module] = []
+        for in_dim, out_dim in zip(dims[:-2], dims[1:-1]):
+            linear = nn.Linear(in_dim, out_dim)
+            _init_layer(linear)
+            layers.append(linear)
+            layers.append(activation())
+        final_linear = nn.Linear(dims[-2], dims[-1])
+        _init_layer(final_linear)
+        layers.append(final_linear)
+        if output_activation is not None:
+            layers.append(output_activation())
+        self.model = nn.Sequential(*layers)
+
+    def forward(self, inputs: torch.Tensor) -> torch.Tensor:  # noqa: D401
+        return self.model(inputs)
+
+
+class GaussianPolicy(nn.Module):
+    """Gaussian policy network with Tanh-squashed actions."""
+
+    def __init__(
+        self,
+        observation_dim: int,
+        action_space,
+        hidden_dims: Sequence[int] = (256, 256),
+        log_std_bounds: Tuple[float, float] = LOG_STD_MIN_MAX,
+    ) -> None:
+        super().__init__()
+        self.net = MLP(observation_dim, hidden_dims, output_dim=2 * action_space.shape[0])
+        self.log_std_bounds = log_std_bounds
+        high = np.asarray(action_space.high, dtype=np.float32)
+        low = np.asarray(action_space.low, dtype=np.float32)
+        if high.shape != low.shape:
+            raise ValueError("Action space high/low must have the same shape")
+        action_scale = (high - low) / 2.0
+        action_bias = (high + low) / 2.0
+        self.register_buffer("action_scale", torch.as_tensor(action_scale, dtype=torch.float32))
+        self.register_buffer("action_bias", torch.as_tensor(action_bias, dtype=torch.float32))
+
+    def _get_mean_log_std(self, observation: torch.Tensor) -> Tuple[torch.Tensor, torch.Tensor]:
+        output = self.net(observation)
+        mean, log_std = torch.chunk(output, chunks=2, dim=-1)
+        log_std = torch.tanh(log_std)
+        min_log_std, max_log_std = self.log_std_bounds
+        log_std = min_log_std + 0.5 * (max_log_std - min_log_std) * (log_std + 1.0)
+        return mean, log_std
+
+    def forward(self, observation: torch.Tensor) -> Tuple[torch.Tensor, torch.Tensor]:
+        mean, log_std = self._get_mean_log_std(observation)
+        std = torch.exp(log_std)
+        return mean, std
+
+    def sample(
+        self, observation: torch.Tensor
+    ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        """Sample reparameterised actions and their log probabilities."""
+        mean, log_std = self._get_mean_log_std(observation)
+        std = torch.exp(log_std)
+        normal = Normal(mean, std)
+        x_t = normal.rsample()
+        y_t = torch.tanh(x_t)
+        action = y_t * self.action_scale + self.action_bias
+        log_prob = normal.log_prob(x_t)
+        log_prob -= torch.log(torch.clamp(self.action_scale * (1 - y_t.pow(2)) + EPS, min=EPS))
+        log_prob = log_prob.sum(dim=-1, keepdim=True)
+        mean_action = torch.tanh(mean) * self.action_scale + self.action_bias
+        return action, log_prob, mean_action
+
+    def act(self, observation: torch.Tensor, deterministic: bool = False) -> torch.Tensor:
+        if deterministic:
+            mean, _ = self.forward(observation)
+            return torch.tanh(mean) * self.action_scale + self.action_bias
+        action, _, _ = self.sample(observation)
+        return action
+
+
+class QNetwork(nn.Module):
+    """State-action value function parameterised by an MLP."""
+
+    def __init__(
+        self,
+        observation_dim: int,
+        action_dim: int,
+        hidden_dims: Sequence[int] = (256, 256),
+    ) -> None:
+        super().__init__()
+        self.net = MLP(observation_dim + action_dim, hidden_dims, output_dim=1)
+
+    def forward(self, observation: torch.Tensor, action: torch.Tensor) -> torch.Tensor:
+        inputs = torch.cat([observation, action], dim=-1)
+        return self.net(inputs)

--- a/torch_sac/replay_buffer.py
+++ b/torch_sac/replay_buffer.py
@@ -1,0 +1,64 @@
+"""Simple replay buffer for PyTorch SAC."""
+
+from __future__ import annotations
+
+from typing import Dict, Tuple
+
+import numpy as np
+
+
+class ReplayBuffer:
+    """Fixed-size buffer for storing environment transitions."""
+
+    def __init__(
+        self, observation_shape: Tuple[int, ...], action_shape: Tuple[int, ...], capacity: int
+    ) -> None:
+        if capacity <= 0:
+            raise ValueError("capacity must be positive")
+        self._capacity = int(capacity)
+        self._observations = np.zeros((self._capacity, *observation_shape), dtype=np.float32)
+        self._next_observations = np.zeros_like(self._observations)
+        self._actions = np.zeros((self._capacity, *action_shape), dtype=np.float32)
+        self._rewards = np.zeros((self._capacity, 1), dtype=np.float32)
+        self._dones = np.zeros((self._capacity, 1), dtype=np.float32)
+        self._size = 0
+        self._index = 0
+
+    def add(
+        self,
+        observation: np.ndarray,
+        action: np.ndarray,
+        reward: float,
+        next_observation: np.ndarray,
+        done: float,
+    ) -> None:
+        """Add a transition to the buffer."""
+        self._observations[self._index] = observation
+        self._actions[self._index] = action
+        self._rewards[self._index] = reward
+        self._next_observations[self._index] = next_observation
+        self._dones[self._index] = done
+
+        self._index = (self._index + 1) % self._capacity
+        self._size = min(self._size + 1, self._capacity)
+
+    def sample(self, batch_size: int) -> Dict[str, np.ndarray]:
+        """Uniformly sample a batch of transitions."""
+        if self._size == 0:
+            raise ValueError("Cannot sample from an empty replay buffer")
+        indices = np.random.randint(0, self._size, size=batch_size)
+        batch = {
+            "observations": self._observations[indices],
+            "actions": self._actions[indices],
+            "rewards": self._rewards[indices],
+            "next_observations": self._next_observations[indices],
+            "dones": self._dones[indices],
+        }
+        return batch
+
+    def __len__(self) -> int:
+        return self._size
+
+    @property
+    def capacity(self) -> int:
+        return self._capacity

--- a/torch_sac/trainer.py
+++ b/torch_sac/trainer.py
@@ -1,0 +1,219 @@
+"""Training loop for the PyTorch SAC implementation."""
+
+from __future__ import annotations
+
+import json
+import math
+import time
+from collections import defaultdict
+from pathlib import Path
+from typing import Dict, Tuple
+
+import numpy as np
+
+try:  # pragma: no cover - optional dependency
+    import gymnasium as gym
+except ImportError:  # pragma: no cover - fall back to classic gym
+    import gym
+
+from .agent import SACAgent
+from .config import TrainConfig
+from .logger import CSVLogger
+from .replay_buffer import ReplayBuffer
+from .utils import env_reset, env_step, set_seed_everywhere
+
+
+def evaluate_policy(
+    env: "gym.Env", agent: SACAgent, episodes: int, deterministic: bool, seed: int | None
+) -> Tuple[float, float]:
+    returns = []
+    lengths = []
+    for episode in range(episodes):
+        episode_seed = None if seed is None else seed + episode
+        observation = env_reset(env, seed=episode_seed)
+        done = False
+        episode_return = 0.0
+        episode_length = 0
+        while not done:
+            action = agent.act(observation, deterministic=deterministic)
+            action = np.clip(action, env.action_space.low, env.action_space.high)
+            observation, reward, terminated, truncated, _ = env_step(env, action)
+            done = terminated or truncated
+            episode_return += reward
+            episode_length += 1
+        returns.append(episode_return)
+        lengths.append(episode_length)
+    return float(np.mean(returns)), float(np.mean(lengths))
+
+
+def train(config: TrainConfig) -> Path:
+    """Run SAC training according to ``config`` and return the output directory."""
+    run_root = Path(config.log_dir).expanduser()
+    run_root.mkdir(parents=True, exist_ok=True)
+    run_name = f"{config.env_id}_{time.strftime('%Y%m%d-%H%M%S')}_seed{config.seed}"
+    run_dir = run_root / run_name
+    run_dir.mkdir(parents=False, exist_ok=False)
+
+    with (run_dir / "config.json").open("w", encoding="utf-8") as handle:
+        json.dump(config.to_dict(), handle, indent=2)
+
+    if config.update_every <= 0:
+        raise ValueError("config.update_every must be positive")
+    if config.gradient_steps <= 0:
+        raise ValueError("config.gradient_steps must be positive")
+    if config.batch_size <= 0:
+        raise ValueError("config.batch_size must be positive")
+
+    env = gym.make(config.env_id)
+    eval_env = gym.make(config.env_id)
+    if config.max_episode_steps is not None:
+        env = gym.wrappers.TimeLimit(env, max_episode_steps=config.max_episode_steps)
+        eval_env = gym.wrappers.TimeLimit(eval_env, max_episode_steps=config.max_episode_steps)
+
+    set_seed_everywhere(config.seed)
+    try:
+        env.action_space.seed(config.seed)
+    except AttributeError:
+        pass
+    try:
+        eval_env.action_space.seed(config.seed + 1000)
+    except AttributeError:
+        pass
+
+    replay_buffer = ReplayBuffer(env.observation_space.shape, env.action_space.shape, config.replay_size)
+    agent = SACAgent(
+        env.observation_space,
+        env.action_space,
+        hidden_dims=config.hidden_dims,
+        lr=config.lr,
+        gamma=config.gamma,
+        tau=config.tau,
+        automatic_entropy_tuning=config.auto_entropy_tuning,
+        target_entropy=config.target_entropy,
+        device=config.device,
+    )
+
+    observation = env_reset(env, seed=config.seed)
+    episode_return = 0.0
+    episode_length = 0
+    completed_episodes = 0
+    last_update_metrics: Dict[str, float] = {}
+
+    eval_seed = config.seed + 10_000
+
+    with CSVLogger(run_dir / "progress.csv") as logger:
+        for step in range(1, config.total_steps + 1):
+            if step <= config.start_steps:
+                action = env.action_space.sample()
+            else:
+                action = agent.act(observation, deterministic=False)
+            action = np.asarray(action, dtype=np.float32)
+            action = np.clip(action, env.action_space.low, env.action_space.high)
+
+            next_observation, reward, terminated, truncated, info = env_step(env, action)
+            done = terminated or truncated
+            episode_return += reward
+            episode_length += 1
+
+            timeout = bool(info.get("TimeLimit.truncated", False))
+            done_for_buffer = 1.0 if terminated or (truncated and not timeout) else 0.0
+            replay_buffer.add(observation, action, reward, next_observation, done_for_buffer)
+
+            observation = next_observation
+            if done:
+                log_entry = {
+                    "step": step,
+                    "episodes": completed_episodes + 1,
+                    "episode_return": episode_return,
+                    "episode_length": episode_length,
+                    "eval_return": math.nan,
+                    "eval_length": math.nan,
+                    "replay_size": len(replay_buffer),
+                    "alpha": last_update_metrics.get("alpha", math.nan),
+                    "policy_loss": last_update_metrics.get("policy_loss", math.nan),
+                    "qf1_loss": last_update_metrics.get("qf1_loss", math.nan),
+                    "qf2_loss": last_update_metrics.get("qf2_loss", math.nan),
+                    "alpha_loss": last_update_metrics.get("alpha_loss", math.nan),
+                    "entropy": last_update_metrics.get("entropy", math.nan),
+                }
+                logger.log(log_entry)
+                observation = env_reset(env)
+                episode_return = 0.0
+                episode_length = 0
+                completed_episodes += 1
+
+            if (
+                step >= config.update_after
+                and step % config.update_every == 0
+                and len(replay_buffer) >= config.batch_size
+            ):
+                metrics_accumulator: Dict[str, float] = defaultdict(float)
+                for _ in range(config.gradient_steps):
+                    batch = replay_buffer.sample(config.batch_size)
+                    metrics = agent.update(batch)
+                    for key, value in metrics.items():
+                        metrics_accumulator[key] += value
+                last_update_metrics = {
+                    key: value / config.gradient_steps for key, value in metrics_accumulator.items()
+                }
+
+            if config.eval_interval and step % config.eval_interval == 0:
+                eval_return, eval_length = evaluate_policy(
+                    eval_env, agent, config.eval_episodes, config.deterministic_eval, eval_seed
+                )
+                eval_seed += config.eval_episodes
+                log_entry = {
+                    "step": step,
+                    "episodes": completed_episodes,
+                    "episode_return": math.nan,
+                    "episode_length": math.nan,
+                    "eval_return": eval_return,
+                    "eval_length": eval_length,
+                    "replay_size": len(replay_buffer),
+                    "alpha": last_update_metrics.get("alpha", math.nan),
+                    "policy_loss": last_update_metrics.get("policy_loss", math.nan),
+                    "qf1_loss": last_update_metrics.get("qf1_loss", math.nan),
+                    "qf2_loss": last_update_metrics.get("qf2_loss", math.nan),
+                    "alpha_loss": last_update_metrics.get("alpha_loss", math.nan),
+                    "entropy": last_update_metrics.get("entropy", math.nan),
+                }
+                logger.log(log_entry)
+                print(
+                    f"Step {step:,} | Episodes {completed_episodes} | "
+                    f"Eval return {eval_return:.2f} | Eval length {eval_length:.1f}"
+                )
+
+            if config.save_interval and step % config.save_interval == 0:
+                checkpoint_path = run_dir / f"checkpoint_{step:08d}.pt"
+                agent.save(checkpoint_path)
+
+        # Final evaluation at the end of training
+        eval_return, eval_length = evaluate_policy(
+            eval_env,
+            agent,
+            config.eval_episodes,
+            config.deterministic_eval,
+            eval_seed if config.eval_interval else None,
+        )
+        logger.log(
+            {
+                "step": config.total_steps,
+                "episodes": completed_episodes,
+                "episode_return": math.nan,
+                "episode_length": math.nan,
+                "eval_return": eval_return,
+                "eval_length": eval_length,
+                "replay_size": len(replay_buffer),
+                "alpha": last_update_metrics.get("alpha", math.nan),
+                "policy_loss": last_update_metrics.get("policy_loss", math.nan),
+                "qf1_loss": last_update_metrics.get("qf1_loss", math.nan),
+                "qf2_loss": last_update_metrics.get("qf2_loss", math.nan),
+                "alpha_loss": last_update_metrics.get("alpha_loss", math.nan),
+                "entropy": last_update_metrics.get("entropy", math.nan),
+            }
+        )
+        agent.save(run_dir / "final_policy.pt")
+
+    env.close()
+    eval_env.close()
+    return run_dir

--- a/torch_sac/utils.py
+++ b/torch_sac/utils.py
@@ -1,0 +1,66 @@
+"""Utility helpers for the PyTorch SAC implementation."""
+
+from __future__ import annotations
+
+import random
+from typing import Any, Dict, Tuple
+
+import numpy as np
+import torch
+
+
+def set_seed_everywhere(seed: int) -> None:
+    """Seed Python, NumPy and PyTorch RNGs."""
+    random.seed(seed)
+    np.random.seed(seed)
+    torch.manual_seed(seed)
+    if torch.cuda.is_available():
+        torch.cuda.manual_seed_all(seed)
+
+
+def soft_update(source: torch.nn.Module, target: torch.nn.Module, tau: float) -> None:
+    """Soft-update target network parameters."""
+    if not 0.0 <= tau <= 1.0:
+        raise ValueError("tau must be in [0, 1]")
+    for target_param, param in zip(target.parameters(), source.parameters()):
+        target_param.data.mul_(1.0 - tau)
+        target_param.data.add_(tau * param.data)
+
+
+def hard_update(source: torch.nn.Module, target: torch.nn.Module) -> None:
+    """Copy parameters from ``source`` to ``target``."""
+    target.load_state_dict(source.state_dict())
+
+
+def to_tensor(array: np.ndarray, device: torch.device) -> torch.Tensor:
+    """Convert a NumPy array to a float32 tensor on ``device``."""
+    return torch.as_tensor(array, dtype=torch.float32, device=device)
+
+
+def env_reset(env: Any, seed: int | None = None) -> Any:
+    """Gym/Gymnasium compatible environment reset."""
+    try:
+        result = env.reset(seed=seed)
+    except TypeError:
+        if seed is not None:
+            try:
+                env.seed(seed)
+            except AttributeError:
+                pass
+        result = env.reset()
+    if isinstance(result, tuple):
+        observation, *_ = result
+    else:
+        observation = result
+    return observation
+
+
+def env_step(env: Any, action: np.ndarray) -> Tuple[Any, float, bool, bool, Dict[str, Any]]:
+    """Step the environment with compatibility across Gym versions."""
+    result = env.step(action)
+    if len(result) == 5:
+        observation, reward, terminated, truncated, info = result
+    else:
+        observation, reward, done, info = result
+        terminated, truncated = bool(done), False
+    return observation, float(reward), bool(terminated), bool(truncated), info or {}


### PR DESCRIPTION
## Summary
- add a self-contained `torch_sac` package that implements Soft Actor-Critic with PyTorch and modern Gym APIs
- provide a configurable CLI entry point plus Windows-focused requirements to train Walker2d with Python 3.10
- document the new workflow and add smoke tests for the PyTorch SAC components
- add an analysis toolkit for `progress.csv` logs with a CLI to generate publication-ready figures and summary tables

## Testing
- pytest tests/torch_sac -q *(skipped: pandas/matplotlib/seaborn not installed in CI image)*

------
https://chatgpt.com/codex/tasks/task_e_68cbbbb1f12c8328adb98f0680472d67